### PR TITLE
Corrections for hypervisor extension

### DIFF
--- a/profiles.adoc
+++ b/profiles.adoc
@@ -814,14 +814,12 @@ supported-optional without the hypervisor extension, as otherwise
 there are no RVA22S64 supported options with relevant state to
 control.
 
-- `hstatus.VTVM`, `hstatus.VTW`, and `hstatus.VTSR` must be writable.
-
 - For any `hpmcounter` that is not read-only zero, the corresponding bit
   in `hcounteren` must be writable.
 
-- `htval` and `vstval` must be written in all cases described above for `stval`.
+- `vstval` must be written in all cases described above for `stval`.
 
-- `htval2` must be written with the faulting guest physical address in all
+- `htval` must be written with the faulting guest physical address in all
   circumstances permitted by the ISA.
 
 - `vstvec.MODE` must be capable of holding the value 0 (Direct).


### PR DESCRIPTION
In CSR `hstatus`, bits VTVM, VTW, and VTSR are always writable.  (If there's any doubt about that fact, a clarification is needed in the Privileged ISA document.)

CSR `htval` isn't written the same as `stval`, and there is no `htval2`.