### PR TITLE
Workflow updates for PDF building and Release Generation

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -11,22 +11,35 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      prerelease:
-        description: 'Generate a pre-release.'
-        required: false 
-        type: boolean
+  workflow_call:
+    outputs:
+      name:
+        description: "The base name of the pdf file (without .pdf extensions)"
+        value: ${{ jobs.build.outputs.name }}
+      pdf-name:
+        description: "The name of the pdf file (with .pdf extensions)"
+        value: ${{ jobs.build.outputs.pdf-name }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     env:
+      NAME: profiles
       APT_PACKAGES_FILE: ${{ github.workspace }}/dependencies/apt_packages.txt
       BUNDLE_GEMFILE: ${{ github.workspace }}/dependencies/Gemfile
       BUNDLE_BIN: ${{ github.workspace }}/bin
       NPM_PACKAGE_FOLDER: ${{ github.workspace }}/dependencies
+    outputs:
+      name: ${{ steps.step1.outputs.name }}
+      pdf-name: ${{ steps.step2.outputs.pdf-name }}
     steps:
+    - name: Set outputs.name
+      id: step1
+      run: echo "::set-output name=name::$NAME"
+    - name: Set outputs.pdf-name
+      id: step2
+      run: echo "::set-output name=pdf-name::$NAME.pdf"
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
@@ -61,28 +74,6 @@ jobs:
     - name: Archive PDF result
       uses: actions/upload-artifact@v2
       with:
-        name: profiles.pdf
-        path: profiles.pdf
+        name: ${{ env.NAME }}.pdf
+        path: ${{ env.NAME }}.pdf
         retention-days: 7
-    - name: Create Release
-      id: create_release
-      if: ${{ github.event.inputs.prerelease }}
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref_name }}
-        release_name: Release ${{ github.ref_name }}
-        draft: false
-        prerelease: true
-    - name: Upload Release Asset
-      id: upload-release-asset
-      if: ${{ github.event.inputs.prerelease }}
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./profiles.pdf
-        asset_name: profiles.pdf
-        asset_content_type: application/pdf

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,55 @@
+# This work flow includes source and PDF in Release.  It relies on the build-pdf workflow to create the PDF.
+#
+# NOTE: At this time it only runs manually.
+
+name: Create Document Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, e.g. X.Y.Z:'
+        required: true
+        type: string
+      prerelease:
+        description: 'Tag as a pre-release?'
+        required: false
+        type: boolean
+        default: true
+      draft:
+        description: 'Create release as a draft?'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-pdf.yml
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ github.event.inputs.version }}
+        release_name: Release ${{ github.event.inputs.version }}
+        draft: ${{ github.event.inputs.draft }}
+        prerelease: ${{ github.event.inputs.prerelease }}
+    - name: Download Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ needs.build.outputs.pdf-name }}
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path:  ${{ needs.build.outputs.pdf-name }}
+        asset_name:  ${{ needs.build.outputs.name }}_${{ github.event.inputs.version }}.pdf
+        asset_content_type: application/pdf


### PR DESCRIPTION
The build-pdf.yml workflow has been simplified to just build.  It's also been made callable (within project).  The calls for this action remain unchanged.

A new create-release.yml workflow has been added as a manual workflow option that can be used to build releases with a PDF.  The flow prompts for release name and a couple flag settings (draft and pre-release).  It uses the build-pdf.yml workflow to create the PDF.  Then, it builds the release and add the PDF in additional to the base artifacts.