### PR TITLE
Mark new extension names explicitly

### DIFF
--- a/profiles.adoc
+++ b/profiles.adoc
@@ -635,12 +635,18 @@ NOTE: This is a new extension name.
 - *Ssptead* Page-fault exceptions are raised when a page is accessed
    when A bit is clear, or written when D bit is clear.
 
+NOTE: This is a new extension name.
+
 - *Ssccptr* Main memory regions with both the cacheability and
    coherence PMAs must support hardware page-table reads.
+
+NOTE: This is a new extension name.
 
 - *Sstvecd* `stvec.MODE` must be capable of holding the value 0 (Direct).  When
   `stvec.MODE=Direct`, `stvec.BASE` must be capable of holding any
   valid four-byte-aligned address.
+
+NOTE: This is a new extension name.
 
 - *Sstvala* `stval` must be written with the faulting virtual address for load,
   store, and instruction page-fault, access-fault, and misaligned
@@ -648,6 +654,8 @@ NOTE: This is a new extension name.
   execution of the `ebreak` or `c.ebreak` instructions.  For
   illegal-instruction exceptions, `stval` must be written with the
   faulting instruction.
+
+NOTE: This is a new extension name.
 
 ==== RVA20S64 Optional Extensions
 
@@ -663,8 +671,8 @@ RVA20S64 has the following privileged options:
 
 - *Ssu64xl* `sstatus.UXL`=64 
 
-NOTE: Software should cope with `status.UXL` field being set to 64.
-This field will be 0 if UXL feature is not implemented.
+NOTE: This is a new extension name.  Software should cope with `status.UXL`
+field being set to 64.  This field will be 0 if UXL feature is not implemented.
 
 == RVA22 Profiles
 
@@ -734,9 +742,9 @@ The following mandatory feature was further restricted in RVA22U64:
 - *Za64rs* Reservation sets are contiguous, naturally aligned, and a
    maximum of 64 bytes.
 
-NOTE: The maximum reservation size has been reduced to match the
-required cache block size.  The minimum reservation size is effectively
-set by the instructions in the mandatory A extension.
+NOTE: This is a new extension name.  The maximum reservation size has been
+reduced to match the required cache block size.  The minimum reservation size
+is effectively set by the instructions in the mandatory A extension.
 
 The following mandatory extensions are new for RVA22U64.
 
@@ -756,7 +764,8 @@ hardware execution.
 - *Zic64b* Cache blocks must be 64 bytes in size, naturally aligned in the
 address space.
 
-NOTE: While the general RISC-V specifications are agnostic to cache
+NOTE: This is a new extension name.
+While the general RISC-V specifications are agnostic to cache
 block size, selecting a common cache block size simplifies the
 specification and use of the following cache-block extensions within
 the application processor profile. Software does not have to query a
@@ -957,8 +966,8 @@ When the hypervisor extension is implemented, the following are also mandatory:
 <
 NOTE: The Smstaten extension specification is an M-mode extension as
 it includes M-mode features, but the supervisor-mode visible
-components of the extension are named as the Ssstaten extension.  Only
-Ssstateen is mandated in the RVA22S64 profile when the hypervisor
+components of the extension are newly named as the Ssstaten extension.
+Only Ssstateen is mandated in the RVA22S64 profile when the hypervisor
 extension is implemented.  These registers are not mandated or
 supported options without the hypervisor extension, as there are no
 RVA22S64 supported options with relevant state to control in the
@@ -966,20 +975,32 @@ absence of the hypervisor extension.
 
 - *Shcounterenw* For any `hpmcounter` that is not read-only zero, the corresponding bit in `hcounteren` must be writable.
 
+NOTE: This is a new extension name.
+
 - *Shvstvala* `vstval` must be written in all cases described above for `stval`.
+
+NOTE: This is a new extension name.
 
 - *Shtvala* `htval` must be written with the faulting guest physical
    address in all circumstances permitted by the ISA.
+
+NOTE: This is a new extension name.
 
 - *Shvstvecd* `vstvec.MODE` must be capable of holding the value 0 (Direct).
   When `vstvec.MODE`=Direct, `vstvec.BASE` must be capable of holding
   any valid four-byte-aligned address.
 
+NOTE: This is a new extension name.
+
 - *Shvsatpa* All translation modes supported in `satp` must be supported in `vsatp`.
+
+NOTE: This is a new extension name.
 
 - *Shgatpa* For each supported virtual memory scheme SvNN supported in
   `satp`, the corresponding hgatp SvNNx4 mode must be supported.  The
   `hgatp` mode Bare must also be supported.
+
+NOTE: This is a new extension name.
 
 ==== RVA22S64 Recommendations
 


### PR DESCRIPTION
From author's view, those 20 extensions are new privileged/unprivileged extension names.
This commit will clarify that they are new extension names.

1.  `Ziccif`
2.  `Ziccrse`
3.  `Ziccamoa`
4.  `Za64rs`
5.  `Za128rs`
6.  `Zicclsm`
7.  `Zic64b`
8.  `Svbare`
9.  `Ssptead` (or renamed `Svptead`)
10. `Ssccptr`
11. `Sstvecd`
12. `Sstvala`
13. `Ssu64xl`
14. `Ssstateen`
15. `Shcounterenw`
16. `Shvstvala`
17. `Shtvala`
18. `Shvstvecd`
19. `Shvsatpa`
20. `Shgatpa`

Following features are excluded from the list.

1.  `Sm` (looks like an extension but I haven't heard that this *is* an extension. If this *is* an extension, it should not be new in this document.)
2.  `Ss` (likewise)
3.  `Sv39` (invalid as extension names)
4.  `Sv48` (likewise)
5.  `Sv57` (likewise)

In ths list, `Ssstateen` might be a candidate to remove "new" mark (assuming that [State Enable Extension](https://github.com/riscv/riscv-state-enable) documentation is updated to define `Ssstateen`).