### PR TITLE
Naming: Adding note to clarify compatiblity with ISA naming strings

### DIFF
--- a/profiles.adoc
+++ b/profiles.adoc
@@ -300,6 +300,12 @@ The initial profiles based on specifications ratified in 2019 are:
 - RVI20U64 basic unprivileged instructions for RV64I
 - RVA20U64, RVA20S64 64-bit application-processor profiles
 
+NOTE: Profile names are embeddable into RISC-V ISA naming strings.
+This implies that there will be no standard ISA extension with a name
+that matches the profile naming convention.  This allows tools that
+process the RISC-V ISA naming string to parse and/or process a combined
+string.
+
 == RVI20 Profiles
 
 The RVI20 profiles document the initial set of unprivileged


### PR DESCRIPTION
The toolchain community would like to embed profile names into the `-march=...` command line argument, which currently processes the RISC-V ISA naming string (as defined in the unpriv spec).

However, there are concerns that these two namespaces are different and therefore potentially conflicting in the future.

To clarify the situation, this change adds a note that the profile's namespace will be compatible with the RISC-V ISA naming string (i.e. there will be no standard extension that will have profile name).

Probably a similar change should be added to the riscv-isa-manual repo.