### PR TITLE
Fix the description of Ssu64xl

### DIFF
--- a/profiles.adoc
+++ b/profiles.adoc
@@ -661,10 +661,8 @@ RVA20S64 has the following privileged options:
 
 - *Sv48* Page-Based 48-bit Virtual-Memory System.
 
-- *Ssu64xl* `sstatus.UXL`=64 
-
-NOTE: Software should cope with `status.UXL` field being set to 64.
-This field will be 0 if UXL feature is not implemented.
+- *Ssu64xl* `sstatus.UXL` must be capable of holding the value 2
+(i.e., UXLEN=64 must be supported).
 
 == RVA22 Profiles
 
@@ -925,10 +923,8 @@ The privileged optional extensions are:
 NOTE: It is expected that Svnapot will be mandatory in the next
 profile release.
 
-- *Ssu64xl* `sstatus.UXL`=64 
-
-NOTE: Software should cope with `status.UXL` field being set to 64.
-This field will be 0 if UXL feature is not implemented.
+- *Ssu64xl* `sstatus.UXL` must be capable of holding the value 2
+(i.e., UXLEN=64 must be supported).
 
 - *Sstc* supervisor-mode timer interrupts.
 


### PR DESCRIPTION
The NOTE's claim that UXL=0 if writable-UXL is unsupported is inconsistent with the priv spec; it should be wired to 2 in this case.

Resolves #75