### PR TITLE
removing RVB22S64 mentions

### DIFF
--- a/rvb23-profile.adoc
+++ b/rvb23-profile.adoc
@@ -217,7 +217,9 @@ mandatory in RVA23S64.
 
 NOTE: Ss1p13 supersedes Ss1p12 but is not yet ratified.
 
-The following privileged extensions were also mandatory in RVB22S64:
+- *Svnapot* NAPOT Translation Contiguity
+
+The following privileged extensions were also mandatory in RVA22S64:
 
 - *Svbare* The `satp` mode Bare must be supported.
 
@@ -250,7 +252,6 @@ The following privileged extensions were also mandatory in RVB22S64:
 - *Ssu64xl* `sstatus.UXL` must be capable of holding the value 2
 (i.e., UXLEN=64 must be supported).
 
-- *Svnapot* NAPOT Translation Contiguity
 
 NOTE: Svnapot is very low cost to provide, so is made mandatory even
 in RVB.
@@ -276,7 +277,7 @@ The privileged optional extensions are:
 
 - *Zkr*  Entropy CSR.
 
-The following hypervisor extension and mandates were also in RVB22S64:
+The following hypervisor extension and mandates were also in RVA22S64:
 
 - *H* The hypervisor extension.
 


### PR DESCRIPTION
I do not think there was such a thing as *RVB22S64*:

- moving `Svnapot` from "mandatory in RVB22S64" (which did not exist I think) to newly mandatory (and also in `RVA23S64`)
- removing mention of *RVB22S64* and replace by the relevant mention of *RVA22S64*