### PR TITLE
Note in RVA22U64 that Zihpm was optional in RVA20U64

### DIFF
--- a/profiles.adoc
+++ b/profiles.adoc
@@ -696,6 +696,8 @@ The following mandatory extensions were present in RVA20U64.
 - *Zicntr* Base counters and timers.
 - *Zihpm* Hardware performance counters.
 
+NOTE: Zihpm was optional in RVA20U64.
+
 - *Ziccif* Main memory regions with both the cacheability and
   coherence PMAs must support instruction fetch, and any instruction
   fetches of naturally aligned power-of-2 sizes up to min(ILEN,XLEN)


### PR DESCRIPTION
Section 6.1.2 contains the statement 'The following mandatory extensions were present in RVA20U64.' followed by a list of extensions, including Zihpm. This statement is a little confusing as Zihpm is an optional extension in RVA20U64.

This commit aims to clear up any confusion by adding a note to section 6.2.1 mentioning that Zihpm was optional in RVA20U64.  This is similar to the note added in rva23-profile.adoc that clarifies the status of 'V' which is optional in RVA22U64 and mandatory in RVA23U64.