### PR TITLE
Add extension requirements/implications

### DIFF
--- a/profiles.adoc
+++ b/profiles.adoc
@@ -720,7 +720,7 @@ correctness, not for performance.
 The following mandatory feature was further restricted in RVA22U64:
 
 - *Za64rs* Reservation sets are contiguous, naturally aligned, and a
-   maximum of 64 bytes.
+   maximum of 64 bytes.  This extension implies the Za128rs extension.
 
 NOTE: This is a new extension name capturing this feature.  The
 maximum reservation size has been reduced to match the required cache
@@ -946,6 +946,7 @@ When the hypervisor extension is implemented, the following are also mandatory:
 - *Ssstateen* Supervisor-mode view of the state-enable extension.  The
    supervisor-mode (`sstateen0-3`) and hypervisor-mode (`hstateen0-3`)
    state-enable registers must be provided.
+   This extension is implied by the Smstateen extension.
 
 NOTE: The Smstateen extension specification is an M-mode extension as
 it includes M-mode features, but the supervisor-mode visible
@@ -959,31 +960,37 @@ absence of the hypervisor extension.
 - *Shcounterenw* For any `hpmcounter` that is not read-only zero, the corresponding bit in `hcounteren` must be writable.
 
 NOTE: This is a new extension name for this feature.
+      This extension requires the H extension.
 
 - *Shvstvala* `vstval` must be written in all cases described above for `stval`.
 
 NOTE: This is a new extension name for this feature.
+      This extension requires the H extension.
 
 - *Shtvala* `htval` must be written with the faulting guest physical
    address in all circumstances permitted by the ISA.
 
 NOTE: This is a new extension name for this feature.
+      This extension requires the H extension.
 
 - *Shvstvecd* `vstvec.MODE` must be capable of holding the value 0 (Direct).
   When `vstvec.MODE`=Direct, `vstvec.BASE` must be capable of holding
   any valid four-byte-aligned address.
 
 NOTE: This is a new extension name for this feature.
+      This extension requires the H extension.
 
 - *Shvsatpa* All translation modes supported in `satp` must be supported in `vsatp`.
 
 NOTE: This is a new extension name for this feature.
+      This extension requires the H extension.
 
 - *Shgatpa* For each supported virtual memory scheme SvNN supported in
   `satp`, the corresponding hgatp SvNNx4 mode must be supported.  The
   `hgatp` mode Bare must also be supported.
 
 NOTE: This is a new extension name for this feature.
+      This extension requires the H extension.
 
 ==== RVA22S64 Recommendations
 

--- a/rva23-profile.adoc
+++ b/rva23-profile.adoc
@@ -110,7 +110,7 @@ The following mandatory extensions were present in RVA22U64.
 - *Zicclsm* Misaligned loads and stores to main memory regions with both the
   cacheability and coherence PMAs must be supported.
 - *Za64rs* Reservation sets are contiguous, naturally aligned, and a
-   maximum of 64 bytes.
+   maximum of 64 bytes.  This extension implies the Za128rs extension.
 - *Zihintpause* Pause instruction.
 - *Zba* Address computation.
 - *Zbb* Basic bit manipulation.
@@ -292,23 +292,30 @@ When the hypervisor extension is implemented, the following are also mandatory:
 - *Ssstateen* Supervisor-mode view of the state-enable extension.  The
    supervisor-mode (`sstateen0-3`) and hypervisor-mode (`hstateen0-3`)
    state-enable registers must be provided.
+   This extension is implied by the Smstateen extension.
 
 - *Shcounterenw* For any `hpmcounter` that is not read-only zero, the corresponding bit in `hcounteren` must be writable.
+  This extension requires the H extension.
 
 - *Shvstvala* `vstval` must be written in all cases described above for `stval`.
+  This extension requires the H extension.
 
 - *Shtvala* `htval` must be written with the faulting guest physical
    address in all circumstances permitted by the ISA.
+   This extension requires the H extension.
 
 - *Shvstvecd* `vstvec.MODE` must be capable of holding the value 0 (Direct).
   When `vstvec.MODE`=Direct, `vstvec.BASE` must be capable of holding
   any valid four-byte-aligned address.
+  This extension requires the H extension.
 
 - *Shvsatpa* All translation modes supported in `satp` must be supported in `vsatp`.
+  This extension requires the H extension.
 
 - *Shgatpa* For each supported virtual memory scheme SvNN supported in
   `satp`, the corresponding hgatp SvNNx4 mode must be supported.  The
   `hgatp` mode Bare must also be supported.
+  This extension requires the H extension.
 
 ==== RVA23S64 Recommendations
 

--- a/rvb23-profile.adoc
+++ b/rvb23-profile.adoc
@@ -112,7 +112,7 @@ The following mandatory extensions are also present in RVA22U64.
 - *Zicclsm* Misaligned loads and stores to main memory regions with both the
   cacheability and coherence PMAs must be supported.
 - *Za64rs* Reservation sets are contiguous, naturally aligned, and a
-   maximum of 64 bytes.
+   maximum of 64 bytes.  This extension implies the Za128rs extension.
 - *Zihintpause* Pause instruction.
 - *Zba* Address computation.
 - *Zbb* Basic bit manipulation.
@@ -282,23 +282,30 @@ When the hypervisor extension is implemented, the following are also mandatory:
 - *Ssstateen* Supervisor-mode view of the state-enable extension.  The
    supervisor-mode (`sstateen0-3`) and hypervisor-mode (`hstateen0-3`)
    state-enable registers must be provided.
+   This extension is implied by the Smstateen extension.
 
 - *Shcounterenw* For any `hpmcounter` that is not read-only zero, the corresponding bit in `hcounteren` must be writable.
+  This extension requires the H extension.
 
 - *Shvstvala* `vstval` must be written in all cases described above for `stval`.
+  This extension requires the H extension.
 
 - *Shtvala* `htval` must be written with the faulting guest physical
    address in all circumstances permitted by the ISA.
+   This extension requires the H extension.
 
 - *Shvstvecd* `vstvec.MODE` must be capable of holding the value 0 (Direct).
   When `vstvec.MODE`=Direct, `vstvec.BASE` must be capable of holding
   any valid four-byte-aligned address.
+  This extension requires the H extension.
 
 - *Shvsatpa* All translation modes supported in `satp` must be supported in `vsatp`.
+  This extension requires the H extension.
 
 - *Shgatpa* For each supported virtual memory scheme SvNN supported in
   `satp`, the corresponding hgatp SvNNx4 mode must be supported.  The
   `hgatp` mode Bare must also be supported.
+  This extension requires the H extension.
 
 ==== RVB23S64 Recommendations
 


### PR DESCRIPTION
Those implications are useful to capture simpler "an extension specifies a feature" principle.

For instance, if the `Za64rs` extension is implemented (at most 64-byte reservation set), the feature specified by the `Za128rs` extension is also implemented (at most 128-byte reservation set).
In that case, implying `Za64rs` → `Za128rs` makes feature detection logic simpler.

Despite that requiring the `H` extension to some `Sh*` extensions in the specification seems redundant (because they are mandatory in the profile if `H` is implemented), it will be useful if those extensions are used separately from the RISC-V Profiles.

Note that one of them (`Smstateen` → `Ssstateen`) is implemented in GNU Binutils version 2.40 or later.