### PR TITLE
Update profiles to reflect new pointer-masking extensions

### DIFF
--- a/rva23-profile.adoc
+++ b/rva23-profile.adoc
@@ -144,8 +144,6 @@ NOTE: V was optional in RVA22U64.
 
 - *Zawrs* Wait on reservation set.
 
-- *Zjpm* Pointer masking (ignore high bits of addresses)
-
 ==== RVA23U64 Optional Extensions
 
 RVA23U64 has ten profile options (Zvkng, Zvksg, Zacas, Zvbc, Zfh, Zbc,
@@ -313,6 +311,12 @@ NOTE: The following extensions were required when the hypervisor was implemented
 - *Shgatpa* For each supported virtual memory scheme SvNN supported in
   `satp`, the corresponding hgatp SvNNx4 mode must be supported.  The
   `hgatp` mode Bare must also be supported.
+
+- *Ssnpm* Pointer masking, with `senvcfg.PME` and `henvcfg.PME` supporting,
+at minimum, settings PMLEN=0 and PMLEN=7.
+
+
+(ignore high bits of addresses)
 
 ==== RVA23S64 Optional Extensions
 

--- a/rvb23-profile.adoc
+++ b/rvb23-profile.adoc
@@ -142,7 +142,6 @@ NOTE: Unclear if other Zve* extensions should also be supported in RVB.
 
 - *Zfhmin* Half-Precision Floating-point transfer and convert.
 - *Zvfhmin* Vector FP16 conversion instructions.
-- *Zjpm* Pointer masking (ignore high bits of addresses)
 
 The following extensions are optional in both RVB23U64 and RVA23U64:
 
@@ -299,6 +298,8 @@ When the hypervisor extension is implemented, the following are also mandatory:
 - *Shgatpa* For each supported virtual memory scheme SvNN supported in
   `satp`, the corresponding hgatp SvNNx4 mode must be supported.  The
   `hgatp` mode Bare must also be supported.
+
+- *Ssnpm* Pointer masking.
 
 ==== RVB23S64 Recommendations
 

--- a/rvm23-profile.adoc
+++ b/rvm23-profile.adoc
@@ -184,8 +184,6 @@ microcontrollers.
 
 - *Zicfisslp* Shadow-stack and landing pads.
 
-- *Zjpm* Pointer masking.
-
 - *Zkt* Data-independent execution time.
 
 - *Zfa* Additional scalar FP instructions.


### PR DESCRIPTION
Strip Zjpm from RVM, since RVM currently only defines the U-mode architecture, but S- or M-mode is needed to define pointer masking.

Update RVA23 to require Ssnpm with PMLEN=7 (see #130 for discussion).

Update RVB23 to make Ssnpm optional.

Resolves #130 