### PR TITLE
Remove Sdtrig

### DIFF
--- a/rva23-profile.adoc
+++ b/rva23-profile.adoc
@@ -286,8 +286,6 @@ NOTE: Sstc was optional in RVA22.
 - *Ssnpm* Pointer masking, with `senvcfg.PME` and `henvcfg.PME` supporting,
 at minimum, settings PMLEN=0 and PMLEN=7.
 
-- *Sdtrig* Debug triggers
-
 - *H* The hypervisor extension.
 
 NOTE: The hypervisor was optional in RVA22.


### PR DESCRIPTION
Removed Sdtrig as a required extension.

In order to allow maximum flexibility, the Debug specification defines Sdtirg with a single requirement: "If Sdtrig is implemented, the Trigger Module must support at least one trigger."

The Sdtrig mandates belong in platform specifications where specific requirements can be provided so that all complaint implementations will have a common base of debug support.

See [What is required for Sdtrig? #134](https://github.com/riscv/riscv-profiles/issues/134) for more details


