### PR TITLE
require Zvkt in RVA23

### DIFF
--- a/rva23-profile.adoc
+++ b/rva23-profile.adoc
@@ -130,6 +130,8 @@ NOTE: V was optional in RVA22U64.
 
 - *Zvbb* Vector bit-manipulation instructions.
 
+- *Zvkt* Vector data-independent execution time.
+
 - *Zihintntl* Non-temporal locality hints.
 
 - *Zicond* Conditional Zeroing instructions.


### PR DESCRIPTION
Closes #133. There hasn't been any discussion there, so I don't know if this change is actually wanted, but I wanted to make it as easy as possible for someone to click the merge button if so :) Here's a copy of the body of that issue:

> RVA23 currently mandates both Zkt and V, so it seems natural that it should also mandate Zvkt. Although the optional Zvkng and Zvksg extensions both imply Zvkt, high-performance implementations of a lot of software-oriented cryptography primitives (like ChaCha and Poly1305) depend only on V and Zvbb, and those implementations are likely to assume Zvkt even if it's not officially required.