### PR TITLE
Tweaks to RVB23 profiles

### DIFF
--- a/rvb23-profile.adoc
+++ b/rvb23-profile.adoc
@@ -220,6 +220,9 @@ NOTE: Ss1p13 supersedes Ss1p12 but is not yet ratified.
 
 - *Svnapot* NAPOT Translation Contiguity
 
+NOTE: Svnapot is very low cost to provide, so is made mandatory even
+in RVB.
+
 The following privileged extensions were also mandatory in RVA22S64:
 
 - *Svbare* The `satp` mode Bare must be supported.
@@ -253,11 +256,9 @@ The following privileged extensions were also mandatory in RVA22S64:
 - *Ssu64xl* `sstatus.UXL` must be capable of holding the value 2
 (i.e., UXLEN=64 must be supported).
 
-
-NOTE: Svnapot is very low cost to provide, so is made mandatory even
-in RVB.
-
 - *Sstc* supervisor-mode timer interrupts.
+
+NOTE: Sstc was optional in RVA22.
 
 ==== RVB23S64 Optional Extensions
 

--- a/rvb23-profile.adoc
+++ b/rvb23-profile.adoc
@@ -128,6 +128,8 @@ The following mandatory extensions are also present in RVA23U64:
 
 - *Zihintntl* Non-temporal locality hints.
 - *Zicond* Conditional Zeroing instructions.
+- *Zimop* Maybe Operations.
+- *Zcmop* Compressed Maybe Operations.
 - *Zcb* Additional 16b compressed instructions.
 - *Zfa* Additional scalar FP instructions.
 - *Zawrs* Wait on reservation set.

--- a/rvb23-profile.adoc
+++ b/rvb23-profile.adoc
@@ -277,6 +277,8 @@ The privileged optional extensions are:
 
 - *Sscofpmf* Count Overflow and Mode-Based Filtering.
 
+- *Ssnpm* Pointer masking.
+
 - *Zkr*  Entropy CSR.
 
 The following hypervisor extension and mandates were also in RVA22S64:
@@ -305,8 +307,6 @@ When the hypervisor extension is implemented, the following are also mandatory:
 - *Shgatpa* For each supported virtual memory scheme SvNN supported in
   `satp`, the corresponding hgatp SvNNx4 mode must be supported.  The
   `hgatp` mode Bare must also be supported.
-
-- *Ssnpm* Pointer masking.
 
 ==== RVB23S64 Recommendations
 

--- a/rvb23-profile.adoc
+++ b/rvb23-profile.adoc
@@ -122,10 +122,13 @@ address space.
 - *Zicbom* Cache-Block Management Operations.
 - *Zicbop* Cache-Block Prefetch Operations.
 - *Zicboz* Cache-Block Zero Operations.
+- *Zkt* Data-independent execution time.
+
+The following mandatory extensions are also present in RVA23U64:
+
 - *Zihintntl* Non-temporal locality hints.
 - *Zicond* Conditional Zeroing instructions.
 - *Zcb* Additional 16b compressed instructions.
-- *Zkt* Data-independent execution time.
 - *Zfa* Additional scalar FP instructions.
 - *Zawrs* Wait on reservation set.
 


### PR DESCRIPTION
- Improve the text, delineating what's new since RVA22U64.
- Mandate Zimop/Zcmop, since they're cheap and simplify the binary-compatibility story
- Make Ssnpm optional, rather than coupling it to the H extension (which I think was an editing error, since it seems illogical)