### PR TITLE
Ssu64xl is actually mandatory in RVA20S64 and RVA22S64

### DIFF
--- a/profiles.adoc
+++ b/profiles.adoc
@@ -643,6 +643,11 @@ NOTE: This is a new extension name for this feature.
 
 NOTE: This is a new extension name for this feature.
 
+- *Ssu64xl* `sstatus.UXL` must be capable of holding the value 2
+(i.e., UXLEN=64 must be supported).
+
+NOTE: This is a new extension name for this feature.
+
 ==== RVA20S64 Optional Extensions
 
 RVA20S64 has one unprivileged option.
@@ -651,14 +656,9 @@ RVA20S64 has one unprivileged option.
 
 NOTE: The number of counters is platform-specific.
 
-RVA20S64 has the following privileged options:
+RVA20S64 has one following privileged option.
 
 - *Sv48* Page-Based 48-bit Virtual-Memory System.
-
-- *Ssu64xl* `sstatus.UXL` must be capable of holding the value 2
-(i.e., UXLEN=64 must be supported).
-
-NOTE: This is a new extension name for this feature.
 
 == RVA22 Profiles
 

--- a/profiles.adoc
+++ b/profiles.adoc
@@ -900,10 +900,16 @@ NOTE: This is new extension name capturing this feature.
 
 - *Svinval* Fine-Grained Address-Translation Cache Invalidation
 
+- *Ssu64xl* `sstatus.UXL` must be capable of holding the value 2
+(i.e., UXLEN=64 must be supported).
+
+NOTE: This is a new extension name for this feature.
+
+
 ==== RVA22S64 Optional Extensions
 
 RVA22S64 has four unprivileged options (Zfh, V, Zkn, Zks) from
-RVA22U64, and eight privileged options (Sv48, Sv57, Svnapot, Ssu64xl,
+RVA22U64, and eight privileged options (Sv48, Sv57, Svnapot,
 Sstc, Sscofpmf, Zkr, H).
 
 The privileged optional extensions are:
@@ -916,11 +922,6 @@ The privileged optional extensions are:
 
 NOTE: It is expected that Svnapot will be mandatory in the next
 profile release.
-
-- *Ssu64xl* `sstatus.UXL` must be capable of holding the value 2
-(i.e., UXLEN=64 must be supported).
-
-NOTE: This is a new extension name for this feature.
 
 - *Sstc* supervisor-mode timer interrupts.
 


### PR DESCRIPTION
RVA20S64 and RVA22S64 are ratified and therefore mustn't be changed, but I claim that the behavior described by Ssu64xl was always mandatory anyway, and so it should have been listed as mandatory, rather than optional, all along.  So this is not a semantic change.

It isn't possible to implement RVA20U64 and RVA20S64 together without having implemented the Ssu64xl extension along the way.  The reasoning is as follows.  When SXLEN=64 (as is the case for RVA20S64), the PrivArch v1.11 spec requires the sstatus.UXL field exist and be encoded the same as MXL.  The table in the M-mode chapter that describes MXL's encoding only lists 3 values (RV32=1, RV64=2, RV128=3); it does not provide for representing XLEN=64 with any value other than 2.  Since RVA20U64 requires UXLEN=64, it follows that sstatus.UXL must be capable of holding the value 2, which is exactly what Ssu64xl stipulates.

The same is true of PrivArch v1.12, and so the same argument holds for RVA22S64.