### PR TITLE
Fix omission of Sspm and Supm from RVA23/RVB23

### DIFF
--- a/rva23-profile.adoc
+++ b/rva23-profile.adoc
@@ -146,6 +146,9 @@ NOTE: V was optional in RVA22U64.
 
 - *Zawrs* Wait on reservation set.
 
+- *Supm* Pointer masking, with the execution environment providing a means to
+   select PMLEN=0 and PMLEN=7 at minimum.
+
 ==== RVA23U64 Optional Extensions
 
 RVA23U64 has eleven profile options (Zvkng, Zvksg, Zacas, Zvbc, Zfh, Zbc,
@@ -362,6 +365,9 @@ spaces or CSRs.
 
 - *Svvptc* Transitions from invalid to valid PTEs will be visible in
    bounded time without an explicit SFENCE.
+
+- *Sspm* Supervisor-mode pointer masking, with the supervisor execution
+   environment providing a means to select PMLEN=0 and PMLEN=7 at minimum.
 
 ===== Transitory Options
 

--- a/rvb23-profile.adoc
+++ b/rvb23-profile.adoc
@@ -188,6 +188,8 @@ NOTE: Unclear if other Zve* extensions should also be supported in RVB.
 - *Zvfhmin* Vector FP16 conversion instructions.
 - *Zvbb* Vector bitmanip extension.
 - *Zvkt* Vector data-independent execution time.
+- *Supm* Pointer masking, with the execution environment providing a means to
+   select PMLEN=0 and PMLEN=7 at minimum.
 
 The following extensions are expansion options in both RVA23U64 and RVB23U64:
 
@@ -314,6 +316,9 @@ The following privileged expansion options are mandatory in RVA22S64 but options
 
 - *Ssnpm* Pointer masking, with `senvcfg.PME` supporting at minimum,
    settings PMLEN=0 and PMLEN=7.
+
+- *Sspm* Supervisor-mode pointer masking, with the supervisor execution
+   environment providing a means to select PMLEN=0 and PMLEN=7 at minimum.
 
 The following hypervisor extension and mandates were also in RVA22S64
 and are available as an expansion option in RVB23S64:


### PR DESCRIPTION
Churn in the pointer-masking extensionology led us to inadvertently omit Sspm and Supm from the profiles; these were meant to be added at the same time that Ssnpm was added, with Supm's existence following from Ssnpm's existence and Sspm being an extension option.