### PR TITLE
Fix a couple of s/isf/is typos in the profiles

### DIFF
--- a/profiles.adoc
+++ b/profiles.adoc
@@ -1008,7 +1008,7 @@ names for existing features, but none require new features:
 - *Zicclsm*: Main memory supports misaligned loads/stores
 - *Za64rs*: Reservation set size of at most 64 bytes
 - *Za128rs*: Reservation set size of at most 128 bytes
-- *Zic64b*: Cache block size isf 64 bytes
+- *Zic64b*: Cache block size is 64 bytes
 - *Svbare*: Bare mode virtual-memory translation supported
 - *Svade*: Raise exceptions on improper A/D bits
 - *Ssccptr*: Main memory supports page table reads

--- a/rva23-profile.adoc
+++ b/rva23-profile.adoc
@@ -458,7 +458,7 @@ Instruction Set Manual; the hyperlinks lead to their separate specifications.
 - *Zama16b*: Misaligned loads, stores, and AMOs to main memory regions that do not cross a naturally aligned 16-byte boundary are atomic.
 - *Za64rs*: Reservation set size of at most 64 bytes
 - *Za128rs*: Reservation set size of at most 128 bytes
-- *Zic64b*: Cache block size isf 64 bytes
+- *Zic64b*: Cache block size is 64 bytes
 - *Svbare*: Bare mode virtual-memory translation supported
 - *Svade*: Raise exceptions on improper A/D bits
 - *Ssccptr*: Main memory supports page table reads

--- a/rvb23-profile.adoc
+++ b/rvb23-profile.adoc
@@ -467,7 +467,7 @@ Instruction Set Manual; the hyperlinks lead to their separate specifications.
 - *Zicclsm*: Main memory supports misaligned loads/stores
 - *Za64rs*: Reservation set size of at most 64 bytes
 - *Za128rs*: Reservation set size of at most 128 bytes
-- *Zic64b*: Cache block size isf 64 bytes
+- *Zic64b*: Cache block size is 64 bytes
 - *Svbare*: Bare mode virtual-memory translation supported
 - *Svade*: Raise exceptions on improper A/D bits
 - *Ssccptr*: Main memory supports page table reads

--- a/rvm23-profile.adoc
+++ b/rvm23-profile.adoc
@@ -306,7 +306,7 @@ Instruction Set Manual; the hyperlinks lead to their separate specifications.
 - *Zicclsm*: Main memory supports misaligned loads/stores
 - *Za64rs*: Reservation set size of at most 64 bytes
 - *Za128rs*: Reservation set size of at most 128 bytes
-- *Zic64b*: Cache block size isf 64 bytes
+- *Zic64b*: Cache block size is 64 bytes
 - *Svbare*: Bare mode virtual-memory translation supported
 - *Svade*: Raise exceptions on improper A/D bits
 - *Ssccptr*: Main memory supports page table reads


### PR DESCRIPTION
Let's fix these typos so they won't be copied anymore.