### PR TITLE
Clarify that Sstvala applies to virtual-instruction exceptions, too

### DIFF
--- a/src/profiles.adoc
+++ b/src/profiles.adoc
@@ -633,7 +633,7 @@ NOTE: This is a new extension name for this feature.
   store, and instruction page-fault, access-fault, and misaligned
   exceptions, and for breakpoint exceptions other than those caused by
   execution of the `ebreak` or `c.ebreak` instructions.  For
-  illegal-instruction exceptions, `stval` must be written with the
+  virtual-instruction and illegal-instruction exceptions, `stval` must be written with the
   faulting instruction.
 
 NOTE: This is a new extension name for this feature.
@@ -887,7 +887,7 @@ NOTE: This is a new extension name for this feature.
   for load, store, and instruction page-fault, access-fault, and
   misaligned exceptions, and for breakpoint exceptions other than
   those caused by execution of the EBREAK or C.EBREAK instructions.
-  For illegal-instruction exceptions, stval must be written with the
+  For virtual-instruction and illegal-instruction exceptions, stval must be written with the
   faulting instruction.
 
 - *Sscounterenw* For any hpmcounter that is not read-only zero, the corresponding bit in scounteren must be writable.

--- a/src/rva23-profile.adoc
+++ b/src/rva23-profile.adoc
@@ -262,7 +262,7 @@ The following privileged extensions were also mandatory in RVA22S64:
   for load, store, and instruction page-fault, access-fault, and
   misaligned exceptions, and for breakpoint exceptions other than
   those caused by execution of the EBREAK or C.EBREAK instructions.
-  For illegal-instruction exceptions, stval must be written with the
+  For virtual-instruction and illegal-instruction exceptions, stval must be written with the
   faulting instruction.
 
 - *Sscounterenw* For any hpmcounter that is not read-only zero, the corresponding bit in scounteren must be writable.

--- a/src/rvb23-profile.adoc
+++ b/src/rvb23-profile.adoc
@@ -278,7 +278,7 @@ in RVB.
   for load, store, and instruction page-fault, access-fault, and
   misaligned exceptions, and for breakpoint exceptions other than
   those caused by execution of the EBREAK or C.EBREAK instructions.
-  For illegal-instruction exceptions, stval must be written with the
+  For virtual-instruction and illegal-instruction exceptions, stval must be written with the
   faulting instruction.
 
 - *Sscounterenw* For any hpmcounter that is not read-only zero, the


### PR DESCRIPTION
Both illegal-instruction and virtual-instruction exceptions must populate stval with the faulting instruction.

This is not a change; the behavior was already mandated by the following clause in the hypervisor spec: https://github.com/riscv/riscv-isa-manual/blob/65c6b5d3e69cdc2bd2658f9639fd10553c4b34e0/src/hypervisor.adoc#L2040-L2041

We are replicating that information here for added clarity.