### PR TITLE
Use B extension in profiles, rather than Zba_Zbb_Zbs.

### DIFF
--- a/src/profiles.adoc
+++ b/src/profiles.adoc
@@ -723,6 +723,13 @@ instructions in the mandatory A extension.
 
 The following mandatory extensions are new for RVA22U64.
 
+- *B* Bit-manipulation instructions.
+
+NOTE: The B extension comprises the Zba, Zbb, and Zbs extensions.
+At the time of RVA22U64's ratification, the B extension had not yet been
+defined, and so RVA22U64 explicitly mandated Zba, Zbb, and Zbs instead.
+Mandating B is equivalent.
+
 - *Zihpm* Hardware performance counters.
 
 NOTE: Zihpm was optional in RVA20U64.
@@ -735,10 +742,6 @@ inclusion in the mandatory extension list signifies that software
 should use the instruction whenever it would make sense and that
 implementors are expected to exploit this information to optimize
 hardware execution.
-
-- *Zba* Address computation.
-- *Zbb* Basic bit manipulation.
-- *Zbs* Single-bit instructions.
 
 - *Zic64b* Cache blocks must be 64 bytes in size, naturally aligned in the
 address space.

--- a/src/rva23-profile.adoc
+++ b/src/rva23-profile.adoc
@@ -86,6 +86,7 @@ The following mandatory extensions were present in RVA22U64.
 - *F* Single-precision floating-point instructions.
 - *D* Double-precision floating-point instructions.
 - *C* Compressed instructions.
+- *B* Bit-manipulation instructions.
 - *Zicsr*  CSR instructions.  These are implied by presence of F.
 - *Zicntr* Base counters and timers.
 - *Zihpm* Hardware performance counters.
@@ -100,9 +101,6 @@ The following mandatory extensions were present in RVA22U64.
 - *Za64rs* Reservation sets are contiguous, naturally aligned, and a
    maximum of 64 bytes.
 - *Zihintpause* Pause hint.
-- *Zba* Address generation.
-- *Zbb* Basic bit-manipulation.
-- *Zbs* Single-bit instructions.
 - *Zic64b* Cache blocks must be 64 bytes in size, naturally aligned in the
 address space.
 - *Zicbom* Cache-block management instructions.
@@ -391,6 +389,7 @@ of the https://github.com/riscv/riscv-isa-manual[RISC-V Instruction Set Manual].
 - H Hypervisor Extension
 - Q Extension for Quad-Precision Floating-Point
 - C Extension for Compressed Instructions
+- B Extension for Bit Manipulation
 - V Extension for Vector Computation
 - Zifencei Instruction-Fetch Fence Extension
 - Zicsr Extension for Control and Status Register Access

--- a/src/rvb23-profile.adoc
+++ b/src/rvb23-profile.adoc
@@ -94,6 +94,7 @@ RVA22U64.
 - *F* Single-precision floating-point instructions.
 - *D* Double-precision floating-point instructions.
 - *C* Compressed instructions.
+- *B* Bit-manipulation instructions.
 - *Zicsr*  CSR instructions.  These are implied by presence of F.
 - *Zicntr* Base counters and timers.
 - *Zihpm* Hardware performance counters.
@@ -108,9 +109,6 @@ RVA22U64.
 - *Za64rs* Reservation sets are contiguous, naturally aligned, and a
    maximum of 64 bytes.
 - *Zihintpause* Pause hint.
-- *Zba* Address generation.
-- *Zbb* Basic bit-manipulation.
-- *Zbs* Single-bit instructions.
 - *Zic64b* Cache blocks must be 64 bytes in size, naturally aligned in the
 address space.
 - *Zicbom* Cache-block management instructions.
@@ -401,6 +399,7 @@ of the https://github.com/riscv/riscv-isa-manual[RISC-V Instruction Set Manual].
 - H Hypervisor Extension
 - Q Extension for Quad-Precision Floating-Point
 - C Extension for Compressed Instructions
+- B Extension for Bit Manipulation
 - V Extension for Vector Computation
 - Zifencei Instruction-Fetch Fence Extension
 - Zicsr Extension for Control and Status Register Access


### PR DESCRIPTION
Conciseness is the goal.  These formulations are equivalent.