### PR TITLE
Use 'B' in the RVM23 profile definition

### DIFF
--- a/src/rvm23-profile.adoc
+++ b/src/rvm23-profile.adoc
@@ -107,9 +107,7 @@ controversial, but RVM is not intended for the smallest possible
 microcontrollers, and including divide instructions reduces
 optionality.
 
-- *Zba* Address computation.
-- *Zbb* Basic bit manipulation.
-- *Zbs* Single-bit instructions.
+- *B* Bit-manipulation instructions.
 
 - *Zicond* Conditional Zeroing instructions.
 


### PR DESCRIPTION
B was introduced as a shorthand for Zba+Zbb+Zbs. Follow the RVA22/RVA23/RVB23 profiles by using it in the RVM23 definition.