### PR TITLE
RVM23 fixes: logo, Makefile tweaks, added script so that RVM23 profile docs build cleanly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ASCIIDOCTOR_HTML := asciidoctor
 OPTIONS := --trace \
            -a compress \
            -a mathematical-format=svg \
-           -a revnumber=${VERSION} \
+           -a revnumber=\"${VERSION}\" \
            -a revremark=\"${REVMARK}\" \
            -a revdate=${DATE} \
            -a pdf-fontsdir=docs-resources/fonts \

--- a/build_rvm23_profile
+++ b/build_rvm23_profile
@@ -1,0 +1,8 @@
+#!/bin/sh
+# The Makefile by default will not build the RVM23 profile, which is still in draft status.
+# This script will set up several useful variables and then invoke the
+# Makefile to build the .pdf and .html for RVM23.
+source=rvm23-profile.adoc
+doc_version=$(grep :revnumber: src/${source} | awk '{print $2}')
+sha_version=$(git rev-parse --short HEAD)
+make VERSION="${doc_version} (SHA ${sha_version})" REVMARK="Draft" DOCS=${source}

--- a/src/rvm23-profile.adoc
+++ b/src/rvm23-profile.adoc
@@ -9,8 +9,8 @@
 :preface-title: Preamble
 :colophon:
 :appendix-caption: Appendix
-:imagesdir: images
-:title-logo-image: image:riscv-images/risc-v_logo.png[pdfwidth=3.25in,align=center]
+:imagesdir: ../docs-resources/images
+:title-logo-image: image:risc-v_logo.png["RISC-V International Logo",pdfwidth=3.25in,align=center]
 // Settings:
 :experimental:
 :reproducible:


### PR DESCRIPTION
A few things:
- The RVM23 profile adoc file was not pointing to the proper logo
- The Makefile had double-quote protection around $(REVMARK) but not around $(VERSION) which becomes important for the next bullet
- If one simply adds rvm23-profile.adoc to the Makefile DOCS variable and does a build, one ends up with a spec that says it is ratified(!!!!!!!!). I added a script, `build_rvm23_profile`, that sets up several variables such that the VERSION ends up printing the actual version embedded in the .adoc file, embeds the git SHA into the VERSION string as well, and also sets REVMARK to "Draft" instead of "This document is in Ratified state."

There is supposed to be a way of setting REVMARK and VERSION in the Makefile based on the target, but I didn't see a way that was working for me with GNU make 4.3, so I gave up and went the script approach instead.

If the build script approach is not considered palatable, let me know. The look and feel of the Makefile made it so a "make rvm23-profile" didn't naturally fit, although of course everything I did in the script could be embedded into the Makefile instead. One nice thing about the script is RVM23 won't be built by default. I didn't add documentation about the script to README.adoc or anything in this commit.