### PR TITLE
Improve description of Ziccamoa

### DIFF
--- a/src/profiles.adoc
+++ b/src/profiles.adoc
@@ -992,7 +992,7 @@ names for existing features, but none require new features:
 
 - *Ziccif*: Main memory supports instruction fetch with atomicity requirement
 - *Ziccrse*: Main memory supports forward progress on LR/SC sequences
-- *Ziccamoa*: Main memory supports all atomics in A
+- *Ziccamoa*: Main memory supports all atomics in Zaamo
 - *Zicclsm*: Main memory supports misaligned loads/stores
 - *Za64rs*: Reservation set size of at most 64 bytes
 - *Za128rs*: Reservation set size of at most 128 bytes

--- a/src/rva23-profile.adoc
+++ b/src/rva23-profile.adoc
@@ -91,7 +91,7 @@ The following mandatory extensions were present in RVA22U64.
   fetches of naturally aligned power-of-2 sizes up to min(ILEN,XLEN)
   (i.e., 32 bits for RVA23) are atomic.
 - *Ziccrse* Main memory regions with both the cacheability and coherence PMAs must support RsrvEventual.
-- *Ziccamoa* Main memory regions with both the cacheability and coherence PMAs must support all atomics in A.
+- *Ziccamoa* Main memory regions with both the cacheability and coherence PMAs must support all atomics in the Zaamo extension.
 - *Zicclsm* Misaligned loads and stores to main memory regions with both the
   cacheability and coherence PMAs must be supported.
 - *Za64rs* Reservation sets are contiguous, naturally aligned, and a
@@ -485,7 +485,7 @@ Instruction Set Manual; the hyperlinks lead to their separate specifications.
 
 - *Ziccif*: Main memory supports instruction fetch with atomicity requirement
 - *Ziccrse*: Main memory supports forward progress on LR/SC sequences
-- *Ziccamoa*: Main memory supports all atomics in A
+- *Ziccamoa*: Main memory supports all atomics in Zaamo
 - *Ziccamoc* Main memory supports atomics in Zacas
 - *Zicclsm*: Main memory supports misaligned loads/stores
 - *Zama16b*: Misaligned loads, stores, and AMOs to main memory regions that do not cross a naturally aligned 16-byte boundary are atomic.

--- a/src/rvb23-profile.adoc
+++ b/src/rvb23-profile.adoc
@@ -104,7 +104,7 @@ RVA22U64.
   fetches of naturally aligned power-of-2 sizes up to min(ILEN,XLEN)
   (i.e., 32 bits for RVB23) are atomic.
 - *Ziccrse* Main memory regions with both the cacheability and coherence PMAs must support RsrvEventual.
-- *Ziccamoa*  Main memory regions with both the cacheability and coherence PMAs must support all atomics in A.
+- *Ziccamoa*  Main memory regions with both the cacheability and coherence PMAs must support all atomics in the Zaamo extension.
 - *Zicclsm* Misaligned loads and stores to main memory regions with both the
   cacheability and coherence PMAs must be supported.
 - *Za64rs* Reservation sets are contiguous, naturally aligned, and a
@@ -455,7 +455,7 @@ Instruction Set Manual; the hyperlinks lead to their separate specifications.
 
 - *Ziccif*: Main memory supports instruction fetch with atomicity requirement
 - *Ziccrse*: Main memory supports forward progress on LR/SC sequences
-- *Ziccamoa*: Main memory supports all atomics in A
+- *Ziccamoa*: Main memory supports all atomics in Zaamo
 - *Ziccamoc* Main memory supports atomics in Zacas
 - *Zicclsm*: Main memory supports misaligned loads/stores
 - *Zama16b*: Misaligned loads, stores, and AMOs to main memory regions that do not cross a naturally aligned 16-byte boundary are atomic.

--- a/src/rvm23-profile.adoc
+++ b/src/rvm23-profile.adoc
@@ -301,7 +301,7 @@ Instruction Set Manual; the hyperlinks lead to their separate specifications.
 
 - *Ziccif*: Main memory supports instruction fetch with atomicity requirement
 - *Ziccrse*: Main memory supports forward progress on LR/SC sequences
-- *Ziccamoa*: Main memory supports all atomics in A
+- *Ziccamoa*: Main memory supports all atomics in Zaamo
 - *Zicclsm*: Main memory supports misaligned loads/stores
 - *Za64rs*: Reservation set size of at most 64 bytes
 - *Za128rs*: Reservation set size of at most 128 bytes


### PR DESCRIPTION
Even though "all atomics in A" arguably says the right thing, it can be misread as including LR/SC, whereas it means only to include AMOs.

Fixes #223